### PR TITLE
Fixed moonc exited without error code 0 error

### DIFF
--- a/lib/linter-moonscript.coffee
+++ b/lib/linter-moonscript.coffee
@@ -25,7 +25,7 @@ class LinterMoonscript
       stderr = (err) ->
         output.push err
       exit = (code) =>
-        if code is 0
+        if code is 0 or 1
           messages = @parse options.cwd, output.join ''
           resolve messages
         else


### PR DESCRIPTION
The script was only checking for error code 0 from the moonc operation.. But error code 1 can also happen if moonc found out any issues in the code... Thereby, fixing error #5 