### PR TITLE
Optionally omit globals warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [v1.0.0](https://github.com/AtomLinter/linter-moonscript/tree/v1.0.0) (2016-12-07)
+[Full Changelog](https://github.com/AtomLinter/linter-moonscript/compare/v0.1.2...v1.0.0)
+
+**Implemented enhancements:**
+
+- Implement specs [\#4](https://github.com/AtomLinter/linter-moonscript/issues/4)
+- Install `linter` automatically. [\#3](https://github.com/AtomLinter/linter-moonscript/issues/3)
+- Use helper module [\#1](https://github.com/AtomLinter/linter-moonscript/issues/1)
+- Add CI Configuration [\#8](https://github.com/AtomLinter/linter-moonscript/pull/8) ([Arcanemagus](https://github.com/Arcanemagus))
+- Rewrite in ES2017 [\#7](https://github.com/AtomLinter/linter-moonscript/pull/7) ([Arcanemagus](https://github.com/Arcanemagus))
+
+**Fixed bugs:**
+
+- moonc exited non-zero code  [\#5](https://github.com/AtomLinter/linter-moonscript/issues/5)
+- Rewrite in ES2017 [\#7](https://github.com/AtomLinter/linter-moonscript/pull/7) ([Arcanemagus](https://github.com/Arcanemagus))
+- Fixed moonc exited without error code 0 error [\#6](https://github.com/AtomLinter/linter-moonscript/pull/6) ([AndrewBastin](https://github.com/AndrewBastin))
+
 ## [v0.1.2](https://github.com/AtomLinter/linter-moonscript/tree/v0.1.2) (2015-08-30)
 [Full Changelog](https://github.com/AtomLinter/linter-moonscript/compare/v0.1.1...v0.1.2)
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -7,6 +7,7 @@ import * as helpers from 'atom-linter';
 import { CompositeDisposable } from 'atom';
 
 const parseRegex = /^(?:line)? \[?(\d+)]?(?:: (.+))?/gm;
+const globalRegex = /accessing global/g;
 let executablePath;
 
 export default {
@@ -58,6 +59,7 @@ export default {
 
         const messages = [];
         let match = parseRegex.exec(result);
+        let globalsOmitted = atom.config.get('linter-moonscript.omitGlobalCheck');
         while (match !== null) {
           // Convert the line to 0-indexed for Atom
           const line = Number.parseInt(match[1], 10) - 1;
@@ -78,13 +80,15 @@ export default {
             });
           } else {
             // Regular lint warning
-            messages.push({
-              type: 'Warning',
-              severity: 'warning',
-              filePath,
-              text: match[2],
-              range: helpers.rangeFromLineNumber(textEditor, line),
-            });
+            if (!globalRegex.test(match[2]) && !globalsOmitted) {
+              messages.push({
+                type: 'Warning',
+                severity: 'warning',
+                filePath,
+                text: match[2],
+                range: helpers.rangeFromLineNumber(textEditor, line),
+              });
+            }
           }
 
           // Grab the next match in the output

--- a/lib/init.js
+++ b/lib/init.js
@@ -25,7 +25,7 @@ export default {
     this.subscriptions.add(atom.config.observe('linter-moonscript.omitGlobalCheck',
       (value) => {
         omitGlobalCheck = value;
-      }
+      },
     ));
   },
 
@@ -65,7 +65,6 @@ export default {
 
         const messages = [];
         let match = parseRegex.exec(result);
-        let globalsOmitted = atom.config.get('linter-moonscript.omitGlobalCheck');
         while (match !== null) {
           // Convert the line to 0-indexed for Atom
           const line = Number.parseInt(match[1], 10) - 1;
@@ -85,7 +84,7 @@ export default {
               range: helpers.rangeFromLineNumber(textEditor, line),
             });
           } else {
-            if (!(globalsOmitted && globalRegex.test(match[2]))) {
+            if (!omitGlobalCheck || !globalRegex.test(match[2])) {
               // Regular lint warning
               messages.push({
                 type: 'Warning',

--- a/lib/init.js
+++ b/lib/init.js
@@ -83,17 +83,15 @@ export default {
               text: 'Syntax error',
               range: helpers.rangeFromLineNumber(textEditor, line),
             });
-          } else {
-            if (!omitGlobalCheck || !globalRegex.test(match[2])) {
-              // Regular lint warning
-              messages.push({
-                type: 'Warning',
-                severity: 'warning',
-                filePath,
-                text: match[2],
-                range: helpers.rangeFromLineNumber(textEditor, line),
-              });
-            }
+          } else if (!omitGlobalCheck || !globalRegex.test(match[2])) {
+            // Regular lint warning
+            messages.push({
+              type: 'Warning',
+              severity: 'warning',
+              filePath,
+              text: match[2],
+              range: helpers.rangeFromLineNumber(textEditor, line),
+            });
           }
 
           // Grab the next match in the output

--- a/lib/init.js
+++ b/lib/init.js
@@ -9,6 +9,7 @@ import { CompositeDisposable } from 'atom';
 const parseRegex = /^(?:line)? \[?(\d+)]?(?:: (.+))?/gm;
 const globalRegex = /accessing global/g;
 let executablePath;
+let omitGlobalCheck;
 
 export default {
   activate() {
@@ -20,6 +21,11 @@ export default {
       (value) => {
         executablePath = value;
       },
+    ));
+    this.subscriptions.add(atom.config.observe('linter-moonscript.omitGlobalCheck',
+      (value) => {
+        omitGlobalCheck = value;
+      }
     ));
   },
 
@@ -79,8 +85,8 @@ export default {
               range: helpers.rangeFromLineNumber(textEditor, line),
             });
           } else {
-            // Regular lint warning
-            if (!globalRegex.test(match[2]) && !globalsOmitted) {
+            if (!(globalsOmitted && globalRegex.test(match[2]))) {
+              // Regular lint warning
               messages.push({
                 type: 'Warning',
                 severity: 'warning',

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
       "type": "string",
       "default": "moonc",
       "description": "Full path to the moonscript compiler."
+    },
+    "omitGlobalCheck": {
+      "type": "boolean",
+      "default": false,
+      "description": "Omit \"accessing global\" warning."
     }
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-moonscript",
   "main": "lib/init",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Lint Moonscript sources with moonc",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "omitGlobalCheck": {
       "type": "boolean",
       "default": false,
-      "description": "Omit \"accessing global\" warning."
+      "description": "Omit \"accessing global\" warnings."
     }
   },
   "license": "MIT",


### PR DESCRIPTION
This is a simple config variable that makes linter ignore "accessing global" warnings. It would be very useful since `moonc -l` has no support for this.